### PR TITLE
fix typo in 09-http-web.md

### DIFF
--- a/docs/NS/09-http-web.md
+++ b/docs/NS/09-http-web.md
@@ -230,7 +230,7 @@ Here's the space-time diagram visualising the connection between the two parties
 
 ### HTTP/1.1 with Pipelining
 
-Here's the space-time diagram visualising the connection between the two parties if HTTP/1.0 with pipelining is enabled: 
+Here's the space-time diagram visualising the connection between the two parties if HTTP/1.1 with pipelining is enabled: 
 
 
 <img src="{{ site.baseurl }}/docs/NS/images/cse2024-time-space-diagram-tcp.drawio.png"  class="center_seventy"/>


### PR DESCRIPTION
Paragraph header and image describes http/1.1 but http/1.0 is mentioned instead.