### PR TITLE
fix: correct highlight IAL syntax in Synchronization in C

### DIFF
--- a/docs/OS/09-csync.md
+++ b/docs/OS/09-csync.md
@@ -20,7 +20,7 @@ Singapore University of Technology and Design
 
 # Synchronization in C (POSIX Threads)
 
-{.:highlight}
+{:.highlight}
 > Detailed Learning Objectives
 >
 > 1. **Examine the Monitor Pattern in C**


### PR DESCRIPTION
## Summary

The Kramdown IAL attribute on the "Detailed Learning Objectives" blockquote at the top of `docs/OS/09-csync.md` is written as `{.:highlight}` (period-colon) instead of `{:.highlight}` (colon-period). Because that form isn't valid Kramdown, the literal text `{.:highlight}` renders on the page instead of applying the highlight class.

## Change

One character, one line:

```diff
-{.:highlight}
+{:.highlight}
> Detailed Learning Objectives
```

All 6 other usages of this callout across the OS chapters already use the correct `{:.highlight}` form — this was the only outlier.

## Verification

Live site, before: visit `/50005/os/c-sync` and the literal string `{.:highlight}` appears above the Learning Objectives blockquote, and the blockquote renders without the highlight background.

After merge: the literal text is gone and the blockquote renders with the same highlight styling used in the sibling Java chapter.