### PR TITLE
fix: link IPC forward-reference to Synchronization chapter

### DIFF
--- a/docs/OS/06-ipc.md
+++ b/docs/OS/06-ipc.md
@@ -109,7 +109,7 @@ shmctl(shmid, IPC_RMID, NULL);
 Of course one obvious issue that might happen here is that BOTH writer and reader are accessing the shared memory concurrently, therefore we will run into <span style="color:#f77729;"><b>synchronisation</b></span> problems whereby <span style="color:#f7007f;"><b>writer overwrites before reader finished reading</b></span> or <span style="color:#f7007f;"><b>reader attempts to read an empty memory value before writer finished writing</b></span>.
 {:.error}
 
-We will address such synchronisation problems in the next chapter.
+We will address such synchronisation problems in the [Synchronization chapter](/50005/os/synchronization).
 
 ### Program: IPC without SVC? {#code-ipc-is-impossible-without-system-calls}
 


### PR DESCRIPTION
## Summary

At the end of the "POSIX Shared Memory" section in `docs/OS/06-ipc.md`, the red error callout introduces the writer/reader race problem and is immediately followed by:

> We will address such synchronisation problems in the next chapter.

The next chapter in reading order is **Threads** (07), not Synchronization (08) — so a student following the cross-reference lands in the wrong place. Replace the vague prose with an explicit link to the chapter that actually addresses it.

## Change

One line:

```diff
-We will address such synchronisation problems in the next chapter.
+We will address such synchronisation problems in the [Synchronization chapter](/50005/os/synchronization).
```

Link uses the same hardcoded `/50005/...` style already established in `docs/OS/09-csync.md:46` for cross-chapter references.

## Verification

Visit `/50005/os/ipc`, scroll to the end of "POSIX Shared Memory" (right after the red error callout). The bold "Synchronization chapter" is now a live link that resolves to `/50005/os/synchronization`.

## Scope note

I only touched this one line. I did not batch in the inline `<span style="color:...">` → callout-system migration noted in the audit, since that is a stylistic choice rather than a correctness fix.