### PR TITLE
fix: restore Processes and Threads Synchronization chapter to OS sidebar

### DIFF
--- a/docs/OS/08-synchronization.md
+++ b/docs/OS/08-synchronization.md
@@ -5,7 +5,6 @@ title: Processes and Threads Synchronization
 description: Methods on how processes and threads can be made cooperative
 parent: Operating System
 nav_order: 8
-nav_exclude: true
 ---
 
 * TOC


### PR DESCRIPTION
## Summary

`docs/OS/08-synchronization.md` is currently marked `nav_exclude: true`, so the core synchronization chapter is hidden from the left-hand sidebar. The OS nav jumps **Threads → Synchronization in C** with no theoretical chapter in between, and a student navigating by sidebar cannot reach the chapter unless they already know the `/os/synchronization` URL.

My read is that this exclusion is collateral from the intentional Java-track deprecation (the sibling `09-javasync.md` is also `nav_exclude: true`, and `09-csync.md` is dated Summer 2026 while everything else is Summer 2025). The C-sync chapter *relies on* the theory in chapter 8 — e.g. `09-csync.md:46` links back to `/50005/os/synchronization` as "the previous chapter".

## Change

One line removed:

```diff
 nav_order: 8
-nav_exclude: true
 ---
```

`09-javasync.md` is **not** touched — its `nav_exclude` appears intentional pending the Java-track decision, and that scope belongs in a separate conversation.

## Verification

Load any OS page, e.g. `/50005/os/ipc`. Left sidebar should now show:

```
7.  Threads
8.  Processes and Threads Synchronization   ← restored
8.  Synchronization in C
10. Deadlock
```

## Known minor follow-on (not in this PR)

Both `08-synchronization.md` and `09-csync.md` declare `nav_order: 8`. just-the-docs breaks the tie alphabetically, which yields the correct pedagogical order ("Processes and Threads Synchronization" before "Synchronization in C"), so the sidebar renders correctly. Re-numbering one of the two is a separate, lower-priority cleanup that I'd rather leave to your judgment than bundle into this fix.